### PR TITLE
Remove double type prefix from insight id

### DIFF
--- a/src/search-insights.ts
+++ b/src/search-insights.ts
@@ -55,11 +55,11 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                 return
             }
             const { repositories = 'current' } = insight
-            const viewProviderId = `searchInsights.${id}`
+
             // TODO diff and unregister removed insights
             if (repositories === 'current') {
                 context.subscriptions.add(
-                    sourcegraph.app.registerViewProvider(`${viewProviderId}.directory`, {
+                    sourcegraph.app.registerViewProvider(`${id}.directory`, {
                         where: 'directory',
                         provideView: async ({ viewer }) => {
                             const { repo, path } = resolveDocumentURI(viewer.directory.uri)
@@ -70,19 +70,19 @@ export function activate(context: sourcegraph.ExtensionContext): void {
             } else if (Array.isArray(repositories)) {
                 const provideView = (): Promise<sourcegraph.View> => getInsightContent(repositories, undefined, insight)
                 context.subscriptions.add(
-                    sourcegraph.app.registerViewProvider(`${viewProviderId}.directory`, {
+                    sourcegraph.app.registerViewProvider(`${id}.directory`, {
                         where: 'directory',
                         provideView,
                     })
                 )
                 context.subscriptions.add(
-                    sourcegraph.app.registerViewProvider(`${viewProviderId}.homepage`, {
+                    sourcegraph.app.registerViewProvider(`${id}.homepage`, {
                         where: 'homepage',
                         provideView,
                     })
                 )
                 context.subscriptions.add(
-                    sourcegraph.app.registerViewProvider(`${viewProviderId}.insightsPage`, {
+                    sourcegraph.app.registerViewProvider(`${id}.insightsPage`, {
                         where: 'insightsPage',
                         provideView,
                     })


### PR DESCRIPTION
Now extension logic add a prefix to insight ID 

```
const id = `${searchInsights.inisght}.${id}`
```

As a result we have ids `"searchInsights.searchInsights.insight.someInsightDuplicateTest"`

**Expected behavior** 

All identifiers must include the extension prefix only once
`"searchInsights.insight.someInsightDuplicateTest"`