### PR TITLE
Add `current` scope repository value for the directory view 

### DIFF
--- a/src/search-insights.ts
+++ b/src/search-insights.ts
@@ -93,7 +93,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
 
                     const directoryPageProvider = sourcegraph.app.registerViewProvider(`${id}.directory`, {
                         where: 'directory',
-                        provideView: async ({ viewer}) => {
+                        provideView: async ({ viewer }) => {
                             const { repo, path } = resolveDocumentURI(viewer.directory.uri)
                             return getInsightContent([repo], path, insight)
                         },

--- a/src/search-insights.ts
+++ b/src/search-insights.ts
@@ -93,7 +93,10 @@ export function activate(context: sourcegraph.ExtensionContext): void {
 
                     const directoryPageProvider = sourcegraph.app.registerViewProvider(`${id}.directory`, {
                         where: 'directory',
-                        provideView,
+                        provideView: async ({ viewer}) => {
+                            const { repo, path } = resolveDocumentURI(viewer.directory.uri)
+                            return getInsightContent([repo], path, insight)
+                        },
                     })
 
                     const homePageProvider = sourcegraph.app.registerViewProvider(`${id}.homepage`, {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph-search-insights/issues/6


Insights that display themself on the directory page should always show info about the `current` directory therefore override repositories setting field from the user or org settings when viewed on a repository or directory page 