### PR TITLE
Add fix for count filter in data series query

### DIFF
--- a/src/query-has-count-filter.ts
+++ b/src/query-has-count-filter.ts
@@ -1,0 +1,17 @@
+const COUNT_PREFIX = 'count:'
+
+/**
+ * Returns whether the query specifies a count. Search queries break when count is specified twice.
+ */
+export function queryHasCountFilter(query: string): boolean {
+    return query
+        .split(' ')
+        .map(part => part.trim())
+        .some(part => {
+            if (!part.startsWith(COUNT_PREFIX)) {
+                return false
+            }
+
+            return part.slice(COUNT_PREFIX.length).length > 0
+        })
+}

--- a/src/query-has-count-filter.ts
+++ b/src/query-has-count-filter.ts
@@ -1,17 +1,6 @@
-const COUNT_PREFIX = 'count:'
-
 /**
  * Returns whether the query specifies a count. Search queries break when count is specified twice.
  */
 export function queryHasCountFilter(query: string): boolean {
-    return query
-        .split(' ')
-        .map(part => part.trim())
-        .some(part => {
-            if (!part.startsWith(COUNT_PREFIX)) {
-                return false
-            }
-
-            return part.slice(COUNT_PREFIX.length).length > 0
-        })
+    return /(?<!\s["'])count:(\s*)\d+\b(?!(\s*)["'])/gi.test(query)
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21955

This PR adds logic for the data series query count filter and excludes adding the max count filter value 99999 if the count filter was specified in user search query. 

**Before** 

<img width="395" alt="Screenshot 2021-06-14 at 12 07 24" src="https://user-images.githubusercontent.com/18492575/121868280-7702bd00-cd09-11eb-9844-b3aa22628b91.png">


**After**

<img width="396" alt="Screenshot 2021-06-14 at 12 04 58" src="https://user-images.githubusercontent.com/18492575/121867781-fcd23880-cd08-11eb-955e-67d89ac4f5d8.png">
