### PR TITLE
Fix Safari RegExp support 

### DIFF
--- a/src/query-has-count-filter.ts
+++ b/src/query-has-count-filter.ts
@@ -2,5 +2,5 @@
  * Returns whether the query specifies a count. Search queries break when count is specified twice.
  */
 export function queryHasCountFilter(query: string): boolean {
-    return /(?<!\s["'])count:(\s*)\d+\b(?!(\s*)["'])/gi.test(query)
+    return /\bcount:\d+\b/gi.test(query)
 }


### PR DESCRIPTION
For cathing count: filter in insight creation UI query input we use follow regexp

```
/(?<!\s["'])count:(\s*)\d+\b(?!(\s*)["'])/gi
```
But Safari doesn't support look behind groups in regexp that leads us to a syntax error that completely breaks the app with an invalid group specifier name error


**Note**
This PR contains the same changes that https://github.com/sourcegraph/sourcegraph/pull/22090 has. 