### PR TITLE
Fix `repo:` filter in linked diff search

### DIFF
--- a/src/search-insights.ts
+++ b/src/search-insights.ts
@@ -248,8 +248,8 @@ async function getInsightContent(
                         // easier to read (else the date component may be off by one day)
                         const after = formatISO(sub(date, step))
                         const before = formatISO(date)
-                        const repoFilters = repos.map(repo => `repo:^${escapeRegExp(repo)}$`).join(' ')
-                        const diffQuery = `${repoFilters} type:diff after:${after} before:${before} ${series.query}`
+                        const repoFilter = `repo:^(${repos.map(escapeRegExp).join('|')})$`
+                        const diffQuery = `${repoFilter} type:diff after:${after} before:${before} ${series.query}`
                         url.searchParams.set('q', diffQuery)
                         return url.href
                     }),


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph-search-insights/issues/7 by joining the repo filters with a regex OR `|` instead.